### PR TITLE
feat: H2 to PostgreSQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,35 @@ This is a Spring Boot 3.5 application using Spring Modulith 1.4.3 that demonstra
 
 ### Run Application
 ```bash
-# Run locally (default port 8081, AMQP enabled by default)
+# Run locally (default port 8082, requires PostgreSQL and RabbitMQ)
 ./mvnw spring-boot:run
 
 # Build and run JAR
 ./mvnw clean package
-java -jar target/modulithdemo-0.0.1-SNAPSHOT.jar
+java -jar target/amqp-modulith-0.0.1-SNAPSHOT.jar
+
+# Run with custom database connection
+java -jar target/amqp-modulith-0.0.1-SNAPSHOT.jar \
+  --spring.datasource.url=jdbc:postgresql://localhost:5432/mydb \
+  --spring.datasource.username=myuser \
+  --spring.datasource.password=mypass
 
 # Run without RabbitMQ connection attempts
-java -jar target/modulithdemo-0.0.1-SNAPSHOT.jar \
+java -jar target/amqp-modulith-0.0.1-SNAPSHOT.jar \
   --spring.modulith.events.externalization.enabled=false \
   --spring.rabbitmq.listener.simple.auto-startup=false
+```
+
+### Run with Docker Compose
+```bash
+# Start PostgreSQL and RabbitMQ
+docker-compose up -d
+
+# Run application
+./mvnw spring-boot:run
+
+# Stop services
+docker-compose down
 ```
 
 ## Architecture
@@ -62,7 +80,7 @@ The application follows Spring Modulith conventions with module boundaries defin
 
 1. **Internal Events**: Published via `ApplicationEventPublisher`, consumed by `@ApplicationModuleListener`
 2. **Event Externalization**: Automatic AMQP publishing via `@Externalized` annotations
-3. **Event Publication Registry**: Transactional outbox pattern using H2 database for reliability
+3. **Event Publication Registry**: Transactional outbox pattern using PostgreSQL database for reliability (H2 for tests)
 4. **Inbound AMQP**: Listeners that convert external messages to internal events (active by default)
 
 ### Key Spring Modulith Patterns
@@ -78,18 +96,41 @@ The application follows Spring Modulith conventions with module boundaries defin
 - **`@ModulithTest`**: Test module boundaries and event flows
 - **`@SpringBootTest`**: Full application context tests
 - Test classes should end with `*Tests.java` and be placed in corresponding test packages
+- Tests automatically use H2 in-memory database via `src/test/resources/application.yml`
 
 ## Configuration
 
-Key configuration in `application.yml`:
-- Server port: 8081
+### Production Configuration (`application.yml`)
+- Server port: 8082
+- Database: PostgreSQL (localhost:5432)
 - RabbitMQ: localhost:5672 (guest/guest)
-- H2 in-memory database for Event Publication Registry
-- Event externalization enabled by default
+- Event externalization: Configurable via `spring.modulith.events.externalization.enabled`
+- Event completion mode: UPDATE (keeps event history in database)
+- Event republish on restart: Enabled
 
-Override via environment variables:
+### Test Configuration (`src/test/resources/application.yml`)
+- Server port: Random (0)
+- Database: H2 in-memory (MODE=PostgreSQL for compatibility)
+- Event externalization: Disabled by default
+- Event completion mode: DELETE (clean up immediately)
+
+### Environment Variables
+Override production settings via:
+- `SPRING_DATASOURCE_URL` (default: `jdbc:postgresql://localhost:5432/postgres`)
+- `SPRING_DATASOURCE_USERNAME` (default: `postgres`)
+- `SPRING_DATASOURCE_PASSWORD` (default: `postgres`)
 - `SPRING_RABBITMQ_HOST`, `SPRING_RABBITMQ_PORT`
 - `SPRING_RABBITMQ_USERNAME`, `SPRING_RABBITMQ_PASSWORD`
+
+### Local Development Setup
+For local development, use Docker Compose to run PostgreSQL and RabbitMQ:
+```bash
+docker-compose up -d
+```
+
+This starts:
+- PostgreSQL on port 5432 (user: postgres, password: postgres)
+- RabbitMQ on port 5672 with management UI on port 15672
 
 ## Development Guidelines
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - amqp-modulith-network
 
   rabbitmq:
-    image: 4.1.3-management-alpine
+    image: rabbitmq:4.1.3-management-alpine
     container_name: amqp-modulith-rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: guest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: amqp-modulith-postgres
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - amqp-modulith-network
+
+  rabbitmq:
+    image: 4.1.3-management-alpine
+    container_name: amqp-modulith-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - "5672:5672"   # AMQP port
+      - "15672:15672" # Management UI
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - amqp-modulith-network
+
+volumes:
+  postgres-data:
+    driver: local
+  rabbitmq-data:
+    driver: local
+
+networks:
+  amqp-modulith-network:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -78,14 +78,13 @@
 			<artifactId>spring-rabbit</artifactId>
 		</dependency>
 		
-		<!-- PostgreSQL：用於Jdbc事件登錄表 -->
+		<!-- PostgreSQL：用於生產環境的 JDBC 事件登錄表 -->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<!-- H2：用於測試 -->
-		<!-- H2：簡化Jdbc事件登錄表 -->
+		<!-- H2：用於測試環境 -->
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
-	<artifactId>modulithdemo</artifactId>
+	<artifactId>amqp-modulith</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>modulithdemo</name>
+	<name>amqp-modulith</name>
 	<description>Demo project for Spring Boot</description>
 	<url/>
 	<licenses>
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 		<spring-modulith.version>1.4.3</spring-modulith.version>
+		<dockerImageName>philipz/${project.artifactId}:${project.version}</dockerImageName>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -77,11 +78,18 @@
 			<artifactId>spring-rabbit</artifactId>
 		</dependency>
 		
+		<!-- PostgreSQL：用於Jdbc事件登錄表 -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- H2：用於測試 -->
 		<!-- H2：簡化Jdbc事件登錄表 -->
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
+			<scope>test</scope>
 		</dependency>
 		<!-- JDBC auto-configuration for DataSource (HikariCP) -->
 		<dependency>
@@ -150,6 +158,11 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+                    <image>
+                        <name>${dockerImageName}</name>
+                    </image>
+                </configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/example/modulithdemo/messaging/inbound/amqp/AmqpConstants.java
+++ b/src/main/java/com/example/modulithdemo/messaging/inbound/amqp/AmqpConstants.java
@@ -12,11 +12,11 @@ public final class AmqpConstants {
 
   // Inbound exchange used by external systems to publish new orders (optional bind)
   public static final String BOOKSTORE_EXCHANGE = "BookStoreExchange";
-  public static final String BOOKSTORE_DLX = "BookStoreExchange.DLX";
+  public static final String BOOKSTORE_DLX = "BookStoreDLX";
 
   // Inbound queue our application listens to
   public static final String NEW_ORDERS_QUEUE = "new-orders";
-  public static final String NEW_ORDERS_DLQ = "new-orders.dlq";
+  public static final String NEW_ORDERS_DLQ = "new-orders-dlq";
 
   // Routing Keys for inbound messages
   public static final String ORDERS_NEW_ROUTING = "orders.new";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,17 +5,19 @@ spring:
   application:
     name: demo
   rabbitmq:
-    host: localhost
-    port: 5672
-    username: guest
-    password: guest
+    host: ${SPRING_RABBITMQ_HOST:localhost}
+    port: ${SPRING_RABBITMQ_PORT:5672}
+    username: ${SPRING_RABBITMQ_USERNAME:guest}
+    password: ${SPRING_RABBITMQ_PASSWORD:guest}
     cache:
       channel:
         size: 50   # increase channel cache for higher throughput
 
   datasource:
-    url: jdbc:h2:mem:modulith;MODE=LEGACY;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/postgres}
+    driver-class-name: org.postgresql.Driver
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
 
   modulith:
     events:
@@ -25,9 +27,9 @@ spring:
         schema-initialization:
           enabled: true
       # H2 in-memory: disable restart republish (state is ephemeral)
-      republish-outstanding-events-on-restart: false
+      republish-outstanding-events-on-restart: true
       # Remove completed publications immediately in dev/H2 to avoid growth during long runs
-      completion-mode: DELETE
+      completion-mode: UPDATE
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,18 +18,27 @@ spring:
     driver-class-name: org.postgresql.Driver
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
     password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    hikari:
+      maximum-pool-size: ${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE:10}
+      minimum-idle: ${SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE:2}
+      connection-timeout: ${SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT:30000}
+      idle-timeout: ${SPRING_DATASOURCE_HIKARI_IDLE_TIMEOUT:600000}
+      max-lifetime: ${SPRING_DATASOURCE_HIKARI_MAX_LIFETIME:1800000}
 
   modulith:
     events:
       externalization:
-        enabled: false
+        enabled: ${SPRING_MODULITH_EVENTS_EXTERNALIZATION_ENABLED:true}
       jdbc:
         schema-initialization:
           enabled: true
-      # H2 in-memory: disable restart republish (state is ephemeral)
+      # PostgreSQL: enable restart republish for reliability (events survive restarts)
       republish-outstanding-events-on-restart: true
-      # Remove completed publications immediately in dev/H2 to avoid growth during long runs
+      # UPDATE mode keeps event history for debugging and audit purposes
       completion-mode: UPDATE
+      # Time to live for completed events (7 days = 604800 seconds)
+      # After this period, completed events should be cleaned up via a scheduled job
+      time-to-live: ${SPRING_MODULITH_EVENTS_TIME_TO_LIVE:7d}
 
 logging:
   level:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,57 @@
+# Test configuration - uses H2 in-memory database instead of PostgreSQL
+server:
+  port: 0  # Random port for tests
+
+spring:
+  application:
+    name: demo-test
+
+  # H2 in-memory database for tests
+  datasource:
+    url: jdbc:h2:mem:modulith;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # RabbitMQ settings (same as main config but with localhost defaults)
+  rabbitmq:
+    host: ${SPRING_RABBITMQ_HOST:localhost}
+    port: ${SPRING_RABBITMQ_PORT:5672}
+    username: ${SPRING_RABBITMQ_USERNAME:guest}
+    password: ${SPRING_RABBITMQ_PASSWORD:guest}
+    cache:
+      channel:
+        size: 50
+
+  modulith:
+    events:
+      externalization:
+        enabled: false  # Disable for tests unless specifically testing externalization
+      jdbc:
+        schema-initialization:
+          enabled: true
+      # H2 in-memory: disable restart republish (state is ephemeral)
+      republish-outstanding-events-on-restart: false
+      # DELETE mode for tests to keep database clean
+      completion-mode: DELETE
+
+logging:
+  level:
+    org.springframework.modulith: INFO
+    org.springframework.amqp: INFO
+
+management:
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+app:
+  amqp:
+    new-orders:
+      bind: true
+      retry-max-attempts: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project renamed to amqp-modulith; docker image naming configuration added; PostgreSQL set as production DB, H2 scoped to tests
* **Configuration**
  * Environment-variable driven settings for DB and RabbitMQ with sensible defaults; event externalization enabled, republish-on-restart enabled, completion behavior changed, event TTL added
* **Documentation**
  * Updated run and local development docs and included Docker Compose for PostgreSQL and RabbitMQ; default port updated
* **Tests**
  * Test profile uses in-memory DB, random test port, and test-specific messaging settings
* **Bug Fixes**
  * Message queue identifiers standardized (DLX/DLQ)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->